### PR TITLE
fix rename state.backend from filesystem to hashmap for Flink 2.x

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -86,7 +86,7 @@ services:
       - |
         FLINK_PROPERTIES=
         jobmanager.rpc.address: flink-jobmanager
-        state.backend: filesystem
+        state.backend: hashmap
         state.checkpoints.dir: file:///opt/flink/checkpoints
         heartbeat.interval: 1000
         heartbeat.timeout: 5000
@@ -119,7 +119,7 @@ services:
         FLINK_PROPERTIES=
         jobmanager.rpc.address: flink-jobmanager
         taskmanager.numberOfTaskSlots: 4
-        state.backend: filesystem
+        state.backend: hashmap
         state.checkpoints.dir: file:///opt/flink/checkpoints
         heartbeat.interval: 1000
         heartbeat.timeout: 5000


### PR DESCRIPTION
Flink 2.0 removed the `filesystem` state backend alias. The heap-based backend is now called `hashmap`. The Flink 2.2.0 upgrade changed the runtime image and dependencies but missed this config rename (the docker-compose config has legacy value).
Both Flink jobs (`UserActivityProcessor`, `SensorDataProcessor`) crash on startup with `ClassNotFoundException: filesystem`, and `make demo` hangs at "Waiting for data..."
